### PR TITLE
Removed dependency on collectd nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Requirements
 Attributes
 ==========
 
-* `default['graphite_powershell_functions']['CarbonServer']` FQDN of the carbon host.  Defaults to the node attribute used by the collectd cookbook
-* `default['graphite_powershell_functions']['CarbonServerPort']` port of the carbon host.  Defaults to the node attribute used by the collectd cookbook
-* `default['graphite_powershell_functions']['MetricPath']` Path to prefix on the collected metrics.  Defaults to the node attribute used by the collectd cookbook
-* `default['graphite_powershell_functions']['MetricSendIntervalSeconds']` Interval to grab metrics.  Default to 15
-* `default['graphite_powershell_functions']['TimeZoneOfGraphiteServer']` Timezone of the Graphite server.  Defaults to UTC
+* `default['graphite_powershell_functions']['CarbonServer']` FQDN of the carbon host.  **Required**
+* `default['graphite_powershell_functions']['CarbonServerPort']` port of the carbon host (default: `2003`).
+* `default['graphite_powershell_functions']['MetricPath']` Path to prefix on the collected metrics (default: `powershell.`).
+* `default['graphite_powershell_functions']['MetricSendIntervalSeconds']` Interval to grab metrics (default: 30).
+* `default['graphite_powershell_functions']['TimeZoneOfGraphiteServer']` Timezone of the Graphite server (default `UTC`).
 * `default['graphite_powershell_functions']['PerformanceCounters']` Array of performance counters to collect
 * `default['graphite_powershell_functions']['MetricFilter']` Array of Metrics to filter
 * `default['graphite_powershell_functions']['nssm_archive']` URL of the Non-Sucky Service Manager zip archive

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-default['graphite_powershell_functions']['CarbonServer'] = node['collectd']['graphite']['host']
-default['graphite_powershell_functions']['CarbonServerPort'] = node['collectd']['graphite']['port']
-default['graphite_powershell_functions']['MetricPath'] = node['collectd']['graphite']['prefix']
+default['graphite_powershell_functions']['CarbonServer'] = nil
+default['graphite_powershell_functions']['CarbonServerPort'] = 2003
+default['graphite_powershell_functions']['MetricPath'] = 'powershell.'
 default['graphite_powershell_functions']['MetricSendIntervalSeconds'] = 30
 default['graphite_powershell_functions']['TimeZoneOfGraphiteServer'] = 'UTC'
 default['graphite_powershell_functions']['hostname'] = node.name.gsub('.', '_')

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'graphite_powershell_functions::default' do
   let(:chef_run) do
     ChefSpec::Runner.new(platform: 'Windows', version: '2008R2') do |node|
-      node.set['collectd']['graphite']['host'] = 'graphite.therealtimsmith.com'
-      node.set['collectd']['graphite']['port'] = 2003
-      node.set['collectd']['graphite']['prefix'] = 'servers.prod.'
+      node.set['graphite_powershell_functions']['CarbonServer'] = 'graphite.therealtimsmith.com'
+      node.set['graphite_powershell_functions']['CarbonServerPort'] = 2003
+      node.set['graphite_powershell_functions']['MetricPath'] = 'servers.prod.'
     end.converge(described_recipe)
   end
   subject { chef_run }


### PR DESCRIPTION
The requirement for collectd nodes would cause chef runs to fail if the
nodes were never set.

This sets some sane defaults.

Fixes #1